### PR TITLE
chore(codeowners): set sdk_team as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rudderlabs/sdk_team


### PR DESCRIPTION
## Summary

Adds a root `CODEOWNERS` with `* @rudderlabs/sdk_team` so chore PRs (Dependabot merges, CI fixes) auto-request review from the whole SDK team and any member's approval unblocks them. No CODEOWNERS existed before. Brings this repo in line with the other SDK repos already migrated.

## Changes

- `CODEOWNERS` (new): `* @rudderlabs/sdk_team`

## Testing

Config-only change — verify on the next PR that review is auto-requested from `sdk_team`.

## Screenshots

No UI changes in this PR.

## Notes

Fixes [SDK-5177](https://linear.app/rudderstack/issue/SDK-5177/set-sdk-team-as-code-owners-in-rudder-sdk-amp). No breaking changes or migration steps required.
