### PR TITLE
chore: add new branding images to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+<p align="center">
+  <a href="https://rudderstack.com/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-dark.png">
+      <img alt="RudderStack" width="512" src="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-light.jpg">
+    </picture>
+  </a>
+</p>
+
 # What is RudderStack?
 
 [RudderStack](https://rudderstack.com/) is a **customer data pipeline** tool for collecting, routing and processing data from your websites, apps, cloud tools, and data warehouse.


### PR DESCRIPTION
# Description

Adds the RudderStack branding header to the README, which previously had no logo. Uses the standard theme-aware `<picture>` block (dark variant in dark mode, light as default/fallback) pointing at the canonical assets in the rudder-sdk-js repo — same pattern as the rest of the SDK repos.

Docs-only change.

Linear: https://linear.app/rudderstack/issue/SDK-5116/update-sdk-repositories-and-packaged-assets-with-new-branding-images